### PR TITLE
shortened code for shuffling data

### DIFF
--- a/neural_network_with_matrices.ipynb
+++ b/neural_network_with_matrices.ipynb
@@ -254,35 +254,14 @@
       "metadata": {
         "id": "5pB6hAkSJVGm",
         "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 185
-        },
-        "outputId": "bf873c59-0d1f-489d-8aa8-c5decc385379"
+        "colab": {}
       },
       "source": [
         "x = Network([784, 50, 10])\n",
         "x.SGD(train_batch, 30, 10, 3.0)"
       ],
-      "execution_count": 28,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Epoch 1 Complete\n",
-            "Epoch 2 Complete\n",
-            "Epoch 3 Complete\n",
-            "Epoch 4 Complete\n",
-            "Epoch 5 Complete\n",
-            "Epoch 6 Complete\n",
-            "Epoch 7 Complete\n",
-            "Epoch 8 Complete\n",
-            "Epoch 9 Complete\n",
-            "Epoch 10 Complete\n"
-          ],
-          "name": "stdout"
-        }
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",

--- a/neural_network_with_matrices.ipynb
+++ b/neural_network_with_matrices.ipynb
@@ -6,14 +6,14 @@
       "name": "neural network with matrices",
       "provenance": [],
       "toc_visible": true,
-      "authorship_tag": "ABX9TyOK/TPLo0mhQeHO0U+horyX",
+      "authorship_tag": "ABX9TyMfT4eHAF1WbQKe3Vz0q/Ap",
       "include_colab_link": true
     },
     "kernelspec": {
       "name": "python3",
       "display_name": "Python 3"
     },
-    "accelerator": "GPU"
+    "accelerator": "TPU"
   },
   "cells": [
     {
@@ -23,7 +23,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/WaiWasabi/Neural-Networks/blob/master/neural_network_with_matrices.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/WaiWasabi/Neural-Networks/blob/optimize-data-shuffling/neural_network_with_matrices.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -100,16 +100,16 @@
         "    self.weights = [w - (lr/len(mini_batch))*nw for w, nw in zip(self.weights, nabla_w)]\n",
         "    self.biases = [b - (lr/len(mini_batch))*nb for b, nb in zip(self.biases, nabla_b)]\n",
         "\n",
-        "  def SGD(self, data, mini_batch_size, epochs, learning_rate):\n",
-        "    n = len(data)\n",
+        "  def SGD(self, train_data, mini_batch_size, epochs, learning_rate): # where train_data is a list of tuples (train_input, train_label)\n",
+        "    n = len(train_data)\n",
         "    for i in range(epochs):\n",
-        "      random.shuffle(data)\n",
-        "      mini_batches = [data[k:(k+mini_batch_size)] for k in range(0, n, mini_batch_size)]\n",
+        "      random.shuffle(train_data)\n",
+        "      mini_batches = [train_data[k:(k+mini_batch_size)] for k in range(0, n, mini_batch_size)]\n",
         "      for mini_batch in mini_batches:\n",
         "        self.update_mini_batch(mini_batch, learning_rate)\n",
         "      print(f\"Epoch {i + 1} Complete\")"
       ],
-      "execution_count": 11,
+      "execution_count": 2,
       "outputs": []
     },
     {
@@ -154,14 +154,13 @@
         "      a = sigmoid(np.matmul(w, a) + b)\n",
         "    return a\n",
         "\n",
-        "  def backprop(self, train_input, train_label):\n",
+        "  def backprop(self, train_input, train_label): # uses batch (matrix) inputs of shape (mini_batch_size, x, y)\n",
         "    dCdw = [0]*len(self.weights)\n",
         "    dCdb = [0]*len(self.biases)\n",
         "    activation = train_input\n",
         "    activations = [train_input]\n",
         "    zs = []\n",
         "    b_matrix = [np.array([b for i in range(len(activation))]) for b in self.biases]\n",
-        "\n",
         "    for w, b in zip(self.weights, b_matrix): # forward pass\n",
         "      z = np.matmul(w, activation) + b\n",
         "      activation = sigmoid(z)\n",
@@ -178,28 +177,23 @@
         "    sum_dCdb = [np.sum(nb, axis = 0) for nb in dCdb]\n",
         "    return sum_dCdw, sum_dCdb\n",
         "    \n",
-        "  def update_mini_batch(self, mini_batch, lr):\n",
+        "  def update_mini_batch(self, mini_batch, lr): # where mini_batch is a size (2,) tuple, (train_input, train_label) <- batches\n",
         "    train_input, train_label = mini_batch\n",
         "    dCdw, dCdb = self.backprop(train_input, train_label)\n",
         "    self.weights = [w-(lr/len(train_input))*nw for w, nw in zip(self.weights, dCdw)]\n",
         "    self.biases = [b-(lr/len(train_input))*nb for b, nb in zip(self.biases, dCdb)]\n",
         "\n",
-        "  def SGD(self, train_data, mini_batch_size, epochs, lr):\n",
-        "    train_input, train_label = train_data\n",
-        "    mini_batches = [(train_input[i:i+mini_batch_size], train_label[i:i+mini_batch_size]) for i in range(0, len(train_input), mini_batch_size)]\n",
+        "  def SGD(self, train_data, mini_batch_size, epochs, lr): \n",
+        "    \"\"\"where train_data is a list of tuples (train_data, train_label) ||indivdual inputs, NOT matrices||\"\"\"\n",
         "    for i in range(epochs):\n",
-        "      random.shuffle(mini_batches)\n",
+        "      random.shuffle(train_data)\n",
+        "      mini_batches = [zip(*train_data[i:i+mini_batch_size]) for i in range(0, len(train_data), mini_batch_size)]\n",
         "      for mini_batch in mini_batches:\n",
-        "        train_input, train_label = mini_batch\n",
-        "        mini_batch = [(train_input, train_label) for train_input, train_label in zip(train_input, train_label)]\n",
-        "        random.shuffle(mini_batch)\n",
-        "        mini_batch = zip(*mini_batch)\n",
         "        self.update_mini_batch(mini_batch, lr)\n",
         "      print(f\"Epoch {i + 1} Complete\")\n",
         "\n",
         "  def evaluate(self, test_data):\n",
-        "    train_input, train_label = test_data\n",
-        "    test_results = [(np.argmax(self.feedforward(x)), y) for x, y in zip(train_input, train_label)]\n",
+        "    test_results = [(np.argmax(self.feedforward(x)), y) for x, y in test_data]\n",
         "    return sum(int(x == y) for x, y in test_results)\n",
         "\n",
         "def to_one_hot(data, max):\n",
@@ -208,9 +202,9 @@
         "    one_hot = np.zeros((max, 1))\n",
         "    one_hot[index][0] = 1\n",
         "    output.append(one_hot)\n",
-        "  return np.array(output)\n"
+        "  return np.array(output)"
       ],
-      "execution_count": 12,
+      "execution_count": 26,
       "outputs": []
     },
     {
@@ -239,13 +233,10 @@
         "x_test = np.array([x.reshape(-1, 1)/255 for x in x_test])\n",
         "y_train = to_one_hot(y_train, 10)\n",
         "\n",
-        "matrix_train_batch = (x_train, y_train)\n",
-        "matrix_test_batch = (x_test, y_test)\n",
-        "\n",
         "train_batch = [(x, y) for x, y in zip(x_train, y_train)]\n",
         "test_batch = [(x, y) for x, y in zip(x_test, y_test)]"
       ],
-      "execution_count": 8,
+      "execution_count": 23,
       "outputs": []
     },
     {
@@ -263,14 +254,35 @@
       "metadata": {
         "id": "5pB6hAkSJVGm",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 185
+        },
+        "outputId": "bf873c59-0d1f-489d-8aa8-c5decc385379"
       },
       "source": [
         "x = Network([784, 50, 10])\n",
-        "x.SGD(matrix_train_batch, 30, 10, 3.0)"
+        "x.SGD(train_batch, 30, 10, 3.0)"
       ],
-      "execution_count": null,
-      "outputs": []
+      "execution_count": 28,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Epoch 1 Complete\n",
+            "Epoch 2 Complete\n",
+            "Epoch 3 Complete\n",
+            "Epoch 4 Complete\n",
+            "Epoch 5 Complete\n",
+            "Epoch 6 Complete\n",
+            "Epoch 7 Complete\n",
+            "Epoch 8 Complete\n",
+            "Epoch 9 Complete\n",
+            "Epoch 10 Complete\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "cell_type": "code",
@@ -281,10 +293,10 @@
           "base_uri": "https://localhost:8080/",
           "height": 34
         },
-        "outputId": "1abebf86-a216-47bb-9610-f45d6e35a96c"
+        "outputId": "40c9da09-50de-4a73-daa3-69f20ebca953"
       },
       "source": [
-        "x.evaluate(matrix_test_batch)"
+        "x.evaluate(test_batch)"
       ],
       "execution_count": 29,
       "outputs": [
@@ -292,7 +304,7 @@
           "output_type": "execute_result",
           "data": {
             "text/plain": [
-              "9418"
+              "9403"
             ]
           },
           "metadata": {


### PR DESCRIPTION
significantly reduced steps taken when shuffling training data for the matrix version. 
note on line 58 that each mini batch is now a zip object, not a tuple. 

also renamed some variables in the single-input network to match corresponding variables in the matrix version

added comments to provide clarity on the structure of the data that should be passed into certain methods.

+better performance